### PR TITLE
Downgrade now version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11354,9 +11354,9 @@
       "dev": true
     },
     "now": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/now/-/now-18.0.0.tgz",
-      "integrity": "sha512-MVskFV3xH1hMkpTewPCb3p0SQ17hL7EI1Zb+Ij2wYiRV3X0a6G91GdE2vvFlhsK6rhRHKHZnDQkZ0AnkpnfzHA==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/now/-/now-17.1.1.tgz",
+      "integrity": "sha512-Hmh8eMSt4FxS1YBwaLrdJuzEVm6ZtS4JCY0AZE+JTnTtDGHVaQMUI85FaPvasSIhKLa+7xf6v7lmTgM39VW/8w==",
       "dev": true
     },
     "npm-run-path": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "js-yaml": "^3.13.1",
     "js-yaml-loader": "^1.2.2",
     "lint-staged": "^10.0.8",
-    "now": "^18.0.0",
+    "now": "^17.1.1",
     "postcss-cli": "^7.1.0",
     "postcss-import": "^12.0.1",
     "prettier": "^1.19.1",


### PR DESCRIPTION
18.0.0 was giving us trouble on deploy. It is
ignoring the alias section in the now.json files