### PR TITLE
Fix README regarding clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ access to some shared credentials and accounts.
 1. Clone this repository:
 
    ```shell
-   > git clone https://github.com/covid-modeling/web
+   > git clone https://github.com/covid-modeling/web-ui
    > cd web
    ```
 


### PR DESCRIPTION
repo location in the "Clone this repository" section was incorrect, this should be fixed