### PR TITLE
Add a stats page

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -3,7 +3,7 @@ import ModelInfo from '../components/ModelInfo'
 import models, {ModelSpec} from '../lib/models'
 import styles from './about.module.css'
 
-export default function IndexPage() {
+export default function AboutPage() {
   return (
     <AppFrame loggedIn={false}>
       <div className={styles.AboutPage}>

--- a/pages/stats.module.css
+++ b/pages/stats.module.css
@@ -1,0 +1,11 @@
+.StatsPage {
+  @apply mx-auto;
+  @apply px-10;
+  margin-top: 49px;
+  max-width: 615px;
+}
+
+.StatsPage h1 {
+  @apply mt-8 mb-4;
+  @apply font-bold text-3.25xl;
+}

--- a/pages/stats.tsx
+++ b/pages/stats.tsx
@@ -1,0 +1,78 @@
+import AppFrame from '../components/AppFrame'
+import Table from '../components/Table'
+import {withDB} from '../lib/mysql'
+import {ensureSession} from '../lib/session'
+import {GetServerSideProps} from 'next'
+import * as db from '../lib/db'
+import handleError from '../lib/handle-error'
+import styles from './stats.module.css'
+
+interface Props {
+  usageByUserPerDayStats: any
+  usageByUserStats: any
+}
+
+export default function StatsPage(props: Props) {
+  return (
+    <AppFrame loggedIn={true}>
+      <div className={styles.StatsPage}>
+        <h1>Users</h1>
+
+        <Table>
+          <thead>
+            <tr>
+              <td>GitHub ID</td>
+              <td>Count</td>
+            </tr>
+          </thead>
+          <tbody>
+            {props.usageByUserStats.map((row: any, i: number) => (
+              <tr key={i}>
+                <td>{row.id}</td>
+                <td>{row.count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+
+        <h1>Users per region per day</h1>
+        <Table>
+          <thead>
+            <tr>
+              <td>Region</td>
+              <td>Sub Region</td>
+              <td>Day</td>
+              <td>Count</td>
+            </tr>
+          </thead>
+          <tbody>
+            {props.usageByUserPerDayStats.map((row: any, i: number) => (
+              <tr key={i}>
+                <td>{row.region_id}</td>
+                <td>{row.subregion_id || '-'}</td>
+                <td>{row.day}</td>
+                <td>{row.count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </div>
+    </AppFrame>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = handleError(
+  withDB(conn =>
+    ensureSession(async (ctx, session) => {
+      return {
+        props: {
+          usageByUserPerDayStats: await db.getUsageByUserPerDayStats(
+            conn,
+            session.user
+          ),
+          usageByUserStats: await db.getUsageByUserStats(conn, session.user)
+        }
+      }
+    })
+  )
+)


### PR DESCRIPTION
This page is only available to admins. Currently will show two tables of stats. We will need to iterate a bit and see if these tables are the most useful.

User count.
Users by region per day count.

Just displaying a simple table of data.