### PR TITLE
Models: Bump MC19 to 1.1.0

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -38,7 +38,7 @@ mrc-ide-covid-sim:
 mc19:
   name: Modeling Covid-19
   origin: Modeling Covid-19
-  imageURL: docker.pkg.github.com/covid-modeling/model-runner/modelingcovid-covidmodel-connector:1.0.0
+  imageURL: docker.pkg.github.com/covid-modeling/model-runner/modelingcovid-covidmodel-connector:1.1.0
   isProductionReady: false
   metaURLs:
     code: https://github.com/modelingcovid/covidmodel


### PR DESCRIPTION
Upgrades to most recent model commit, for closer results comparison.