### PR TITLE
Remove the --prod option

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - run: |
           mkdir .now
           echo '{"projectId":"${{secrets.ZEIT_PROJECT_ID}}","orgId":"${{secrets.ZEIT_ORG_ID}}"}' > .now/project.json
-      - run: npx now --token ${{secrets.ZEIT_TOKEN}} -b GITHUB_SHA=${{github.sha}} --prod -A now.prod.json
+      - run: npx now --token ${{secrets.ZEIT_TOKEN}} -b GITHUB_SHA=${{github.sha}} -A now.prod.json
       - run: |
           npx sentry-cli \
             --auth-token "${{secrets.SENTRY_AUTH_TOKEN}}" \


### PR DESCRIPTION
This will avoid us accidentally aliasing staging to prod on deploys.

See: https://vercel.com/docs/now-cli#commands/overview/unique-options/prod