### PR TITLE
Bump imperial to 1.2.0

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -19,7 +19,7 @@ mrc-ide-covid-sim:
   name: CovidSim (Imperial)
   origin: Imperial College
   isProductionReady: true
-  imageURL: docker.pkg.github.com/covid-modeling/model-runner/mrc-ide-covidsim-connector:1.1.0
+  imageURL: docker.pkg.github.com/covid-modeling/model-runner/mrc-ide-covidsim-connector:1.2.0
   metaURLs:
     code: https://github.com/mrc-ide/covid-sim
     paper: https://www.imperial.ac.uk/media/imperial-college/medicine/sph/ide/gida-fellowships/Imperial-College-COVID19-NPI-modelling-16-03-2020.pdf


### PR DESCRIPTION
Bumps the ui to use 1.2.0. This version is still failing for Canada.