### PR TITLE
models: Upgrade the MC19 and CovidSim models to the latest versions.

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -19,7 +19,7 @@ mrc-ide-covid-sim:
   name: CovidSim (Imperial)
   origin: Imperial College
   isProductionReady: true
-  imageURL: docker.pkg.github.com/covid-modeling/model-runner/mrc-ide-covidsim-connector:1.3.0
+  imageURL: docker.pkg.github.com/covid-modeling/model-runner/mrc-ide-covidsim-connector:1.4.0
   metaURLs:
     code: https://github.com/mrc-ide/covid-sim
     paper: https://www.imperial.ac.uk/media/imperial-college/medicine/sph/ide/gida-fellowships/Imperial-College-COVID19-NPI-modelling-16-03-2020.pdf
@@ -38,7 +38,7 @@ mrc-ide-covid-sim:
 mc19:
   name: Modeling Covid-19
   origin: Modeling Covid-19
-  imageURL: docker.pkg.github.com/covid-modeling/model-runner/modelingcovid-covidmodel-connector:1.2.0
+  imageURL: docker.pkg.github.com/covid-modeling/model-runner/modelingcovid-covidmodel-connector:1.4.0
   isProductionReady: false
   metaURLs:
     code: https://github.com/modelingcovid/covidmodel


### PR DESCRIPTION
Related to: https://github.com/covid-modeling/model-runner/issues/18 and https://github.com/covid-modeling/model-runner/pull/16