### PR TITLE
Add international interventions data to db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .env
 .env.build
 now.local.json
+.cache

--- a/lib/international-interventions-parser.ts
+++ b/lib/international-interventions-parser.ts
@@ -1,0 +1,85 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import * as csvjson from 'csvjson'
+import * as iso from 'i18n-iso-countries'
+import {input} from '@covid-modeling/api'
+import {ISODate} from '@covid-modeling/api/dist/src/model-input'
+
+interface PolicyRow {
+  regionId: string
+  subregionId: string | null
+  policy: string | null
+  notes: string | null
+  source: string | null
+  issueDate: input.ISODate | null
+  startDate: input.ISODate | null
+  easeDate: input.ISODate | null
+  expirationDate: input.ISODate | null
+  endDate: input.ISODate | null
+}
+
+export function parseCsv(
+  csv: string,
+  policyName: string,
+  threshold: number
+): PolicyRow[] {
+  const arr = csvjson.toObject(csv) as []
+
+  // each array element is a country
+  // find the earliest date where the threshold is reached and that is the start
+  // continue to find any date where it ends and that is the end
+  return arr.map(countryRow => {
+    const isoCode = iso.alpha3ToAlpha2(countryRow[''])
+
+    // note that dates are pre-sorted
+    const startIndex = Object.values(countryRow).findIndex(
+      level => Number(level) >= threshold
+    )
+    const startDate = Object.keys(countryRow)[startIndex]
+
+    const endIndex = Object.values(countryRow).findIndex(
+      (level, i) => i >= startIndex && Number(level) < threshold
+    )
+    const endDate = Object.keys(countryRow)[endIndex]
+
+    return {
+      regionId: isoCode,
+      subregionId: null,
+      policy: policyName,
+      notes: null,
+      source: null,
+      issueDate: null,
+      startDate: translateDate(startDate),
+      easeDate: null,
+      expirationDate: null,
+      endDate: translateDate(endDate)
+    }
+  })
+}
+
+const months = {
+  jan: '01',
+  feb: '02',
+  mar: '03',
+  apr: '04',
+  may: '05',
+  jun: '06',
+  jul: '07',
+  aug: '08',
+  sep: '09',
+  oct: '10',
+  nov: '11',
+  dec: '12'
+}
+
+function translateDate(ddmmmyyyy: string): ISODate | null {
+  debugger
+  if (!ddmmmyyyy) {
+    return null
+  }
+  const month = (months as any)[ddmmmyyyy.slice(2, 5)]
+  if (!month) {
+    return null
+  }
+  return [ddmmmyyyy.slice(5), month, ddmmmyyyy.slice(0, 2)].join('-')
+}

--- a/lib/international-interventions-parser.ts
+++ b/lib/international-interventions-parser.ts
@@ -4,6 +4,7 @@ import * as csvjson from 'csvjson'
 import * as iso from 'i18n-iso-countries'
 import {input} from '@covid-modeling/api'
 import {ISODate} from '@covid-modeling/api/dist/src/model-input'
+import {DateTime} from 'luxon'
 
 interface PolicyRow {
   regionId: string
@@ -17,6 +18,8 @@ interface PolicyRow {
   expirationDate: input.ISODate | null
   endDate: input.ISODate | null
 }
+
+const dateFormat = 'ddMMMyyyy'
 
 export function parseCsv(
   csv: string,
@@ -55,40 +58,19 @@ export function parseCsv(
         notes: null,
         source: null,
         issueDate: null,
-        startDate: translateDate(startDate),
+        startDate:
+          startDate === null || startDate === undefined
+            ? null
+            : DateTime.fromFormat(startDate, dateFormat).toISODate(),
         easeDate: null,
         expirationDate: null,
-        endDate: translateDate(endDate)
+        endDate:
+          endDate === null || endDate === undefined
+            ? null
+            : DateTime.fromFormat(endDate, dateFormat).toISODate()
       }
     })
     .filter(row => row.regionId)
-}
-
-const months = {
-  jan: '01',
-  feb: '02',
-  mar: '03',
-  apr: '04',
-  may: '05',
-  jun: '06',
-  jul: '07',
-  aug: '08',
-  sep: '09',
-  oct: '10',
-  nov: '11',
-  dec: '12'
-}
-
-// exported for testing
-export function translateDate(ddmmmyyyy: string): ISODate | null {
-  if (!ddmmmyyyy) {
-    return null
-  }
-  const month = (months as any)[ddmmmyyyy.slice(2, 5)]
-  if (!month) {
-    return null
-  }
-  return [ddmmmyyyy.slice(5), month, ddmmmyyyy.slice(0, 2)].join('-')
 }
 
 function getIsoCode(alpha3: string): string {

--- a/lib/new-simulation-state.ts
+++ b/lib/new-simulation-state.ts
@@ -247,10 +247,7 @@ function autoFillParameters(
   subregion: Region | undefined,
   interventions: InterventionMap
 ): InterventionPeriod[] {
-  if (!subregion || region.id !== 'US') {
-    return []
-  }
-  const regionInterventions = interventions[region.id][subregion.id]
+  const regionInterventions = interventions[region.id][subregion?.id || '_self']
   if (!regionInterventions) {
     return []
   }

--- a/lib/simulation-types.ts
+++ b/lib/simulation-types.ts
@@ -65,5 +65,5 @@ export interface Interventions {
  * This is all of our interventions data
  */
 export interface InterventionMap {
-  US: Record<string, Interventions>
+  [key: string]: Record<string, Interventions>
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3419,6 +3419,12 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -5849,6 +5855,18 @@
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-2.0.1.tgz",
       "integrity": "sha512-I2TiqT5iWBEyB8GRfTDP0hiLZ0YeDJZ+upDxjBfOC2lebO5LezQMv7QvIUTzdb64jQyAKLf1AHADtGN+jw6v8Q=="
     },
+    "diacritics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+      "integrity": "sha1-PvqHMj67hj5mls67AILUj/PW96E=",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
     "diff-sequences": {
       "version": "25.2.6",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
@@ -7678,6 +7696,15 @@
       "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
       "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
       "dev": true
+    },
+    "i18n-iso-countries": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-5.3.0.tgz",
+      "integrity": "sha512-Ud3lP2ByK8y5gpy8kFuq7I+EmYF/S+K0dSi/2l+G3Gwk8/ZMTtjUGXEvvwmSLsm1Mx00VTmtGMbkR6fua/rdGg==",
+      "dev": true,
+      "requires": {
+        "diacritics": "1.3.0"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -10659,6 +10686,12 @@
       "requires": {
         "pify": "^3.0.0"
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.11",
@@ -15202,6 +15235,37 @@
         }
       }
     },
+    "ts-node": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.1.tgz",
+      "integrity": "sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
     "ts-pnp": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
@@ -16768,6 +16832,12 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint-plugin-react": "~7.19.0",
     "eslint-plugin-react-hooks": "^3.0.0",
     "husky": "^4.2.3",
+    "i18n-iso-countries": "^5.3.0",
     "jest": "^25.3.0",
     "js-yaml": "^3.13.1",
     "js-yaml-loader": "^1.2.2",
@@ -93,6 +94,7 @@
     "source-map": "^0.7.3",
     "tailwindcss": "^1.2.0",
     "ts-json-schema-generator": "^0.67.1",
+    "ts-node": "^8.10.1",
     "typescript": "^3.8.3"
   },
   "eslintConfig": {

--- a/script/fetch-recorded-data
+++ b/script/fetch-recorded-data
@@ -42,6 +42,8 @@ const ecdcCasesURL = `https://opendata.ecdc.europa.eu/covid19/casedistribution/j
 const covidTrackingURL = 'https://covidtracking.com/api/v1/states/daily.json'
 const usInterventionsURL = `https://raw.githubusercontent.com/COVID19StatePolicy/SocialDistancing/master/data/USstatesCov19distancingpolicy.csv`
 const internationalSchoolClosuresURL = `https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/timeseries/c1_schoolclosing.csv`
+const internationalRestrictionsOnGatheringsURL = `https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/timeseries/c4_restrictionsongatherings.csv`
+const internationalStayAtHomeRequirementsURL = `https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/timeseries/c6_stayathomerequirements.csv`
 
 const db = mysql({
   maxRetries: 5,
@@ -66,20 +68,17 @@ async function main() {
     usaCasesJSON,
     ecdcCasesJSON,
     usInterventionsCSV,
-    internationalSchoolClosuresCSV
+    internationalSchoolClosuresCSV,
+    internationalRestrictionsOnGatheringsCSV,
+    internationalStayAtHomeRequirementsCSV
   ] = await Promise.all([
     fetchCached(covidTrackingURL, cacheDir),
     fetchCached(ecdcCasesURL, cacheDir),
     fetchCached(usInterventionsURL, cacheDir),
-    fetchCached(internationalSchoolClosuresURL, cacheDir)
+    fetchCached(internationalSchoolClosuresURL, cacheDir),
+    fetchCached(internationalRestrictionsOnGatheringsURL, cacheDir),
+    fetchCached(internationalStayAtHomeRequirementsURL, cacheDir)
   ])
-
-  const internationalSchoolClosures = internationalParser.parseCsv(
-    internationalSchoolClosuresCSV,
-    'SchoolClose',
-    2
-  )
-  console.log(internationalSchoolClosures)
 
   // Parse the US case data
   const metricsByState = {}
@@ -165,7 +164,7 @@ async function main() {
       const easeDate = row.DateEased || null
       const expirationDate = row.DateExpiry || null
       const endDate = row.DateEnded || null
-      usInterventionRecords.push([
+      usInterventionRecords.push({
         regionId,
         subregionId,
         policy,
@@ -176,9 +175,44 @@ async function main() {
         easeDate,
         expirationDate,
         endDate
-      ])
+      })
     }
   }
+
+  // parse the international interventions data
+  const internationalSchoolClosures = internationalParser.parseCsv(
+    internationalSchoolClosuresCSV,
+    'SchoolClose',
+    2
+  )
+  const internationalRestrictionsOnGatherings = internationalParser.parseCsv(
+    internationalRestrictionsOnGatheringsCSV,
+    'GathRestrict10',
+    3
+  )
+  const internationalStayAtHomeRequirements = internationalParser.parseCsv(
+    internationalStayAtHomeRequirementsCSV,
+    'StayAtHome',
+    2
+  )
+
+  const allInterventionRecords = usInterventionRecords
+    .concat(internationalSchoolClosures)
+    .concat(internationalRestrictionsOnGatherings)
+    .concat(internationalStayAtHomeRequirements)
+    .filter(row => !!row.startDate)
+    .map(row => [
+      row.regionId,
+      row.subregionId,
+      row.policy,
+      row.notes,
+      row.source,
+      row.issueDate,
+      row.startDate,
+      row.easeDate,
+      row.expirationDate,
+      row.endDate
+    ])
 
   if (cacheDir) {
     fs.writeFileSync(
@@ -189,7 +223,7 @@ async function main() {
 
     fs.writeFileSync(
       path.join(cacheDir, 'intervention-data.json'),
-      JSON.stringify(usInterventionRecords, null, 2),
+      JSON.stringify(allInterventionRecords, null, 2),
       'utf8'
     )
   }
@@ -233,7 +267,7 @@ async function main() {
   try {
     console.log('Inserting interventions data')
 
-    if (!usInterventionRecords.length) {
+    if (!allInterventionRecords.length) {
       throw new Error('No interventions found')
     }
 
@@ -253,10 +287,10 @@ async function main() {
         VALUES
         ?
       `,
-      [usInterventionRecords]
+      [allInterventionRecords]
     )
     console.log(
-      `Saved ${usInterventionRecords.length} records to interventions table...`
+      `Saved ${allInterventionRecords.length} records to interventions table...`
     )
     await db.query(
       'RENAME TABLE intervention_data TO intervention_data_old, intervention_data_import TO intervention_data'

--- a/script/fetch-recorded-data
+++ b/script/fetch-recorded-data
@@ -9,6 +9,14 @@ const mysql = require('serverless-mysql')
 const d3 = require('d3')
 const _ = require('lodash')
 
+require('ts-node').register({
+  project: path.join(__dirname, '../tsconfig.json'),
+  compilerOptions: {
+    module: 'commonjs'
+  }
+})
+const internationalParser = require('../lib/international-interventions-parser')
+
 const cacheDir = process.argv[2]
 if (cacheDir === '--help') {
   console.log(`
@@ -33,6 +41,7 @@ INFO
 const ecdcCasesURL = `https://opendata.ecdc.europa.eu/covid19/casedistribution/json/`
 const covidTrackingURL = 'https://covidtracking.com/api/v1/states/daily.json'
 const usInterventionsURL = `https://raw.githubusercontent.com/COVID19StatePolicy/SocialDistancing/master/data/USstatesCov19distancingpolicy.csv`
+const internationalSchoolClosuresURL = `https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/timeseries/c1_schoolclosing.csv`
 
 const db = mysql({
   maxRetries: 5,
@@ -53,11 +62,24 @@ const db = mysql({
 
 async function main() {
   // Fetch the raw data
-  const [usaCasesJSON, ecdcCasesJSON, usInterventionsCSV] = await Promise.all([
+  const [
+    usaCasesJSON,
+    ecdcCasesJSON,
+    usInterventionsCSV,
+    internationalSchoolClosuresCSV
+  ] = await Promise.all([
     fetchCached(covidTrackingURL, cacheDir),
     fetchCached(ecdcCasesURL, cacheDir),
-    fetchCached(usInterventionsURL, cacheDir)
+    fetchCached(usInterventionsURL, cacheDir),
+    fetchCached(internationalSchoolClosuresURL, cacheDir)
   ])
+
+  const internationalSchoolClosures = internationalParser.parseCsv(
+    internationalSchoolClosuresCSV,
+    'SchoolClose',
+    2
+  )
+  console.log(internationalSchoolClosures)
 
   // Parse the US case data
   const metricsByState = {}

--- a/test/international-interventions-parser.test.ts
+++ b/test/international-interventions-parser.test.ts
@@ -1,7 +1,4 @@
-import {
-  parseCsv,
-  translateDate
-} from '../lib/international-interventions-parser'
+import {parseCsv} from '../lib/international-interventions-parser'
 
 // These are 3 rows taken from real data, but modified to include subthreshold levels and backing off of restrictions
 const data = `,,01jan2020,02jan2020,03jan2020,04jan2020,05jan2020,06jan2020,07jan2020,08jan2020,09jan2020,10jan2020,11jan2020
@@ -121,22 +118,5 @@ describe('international-interventions-parser', () => {
         subregionId: null
       }
     ])
-  })
-
-  it('should parse translate dates', () => {
-    expect(translateDate('21jan1999')).toBe('1999-01-21')
-    expect(translateDate('21feb1999')).toBe('1999-02-21')
-    expect(translateDate('21mar1999')).toBe('1999-03-21')
-    expect(translateDate('21apr1999')).toBe('1999-04-21')
-    expect(translateDate('21may1999')).toBe('1999-05-21')
-    expect(translateDate('21jun1999')).toBe('1999-06-21')
-    expect(translateDate('21jul1999')).toBe('1999-07-21')
-    expect(translateDate('21aug1999')).toBe('1999-08-21')
-    expect(translateDate('21sep1999')).toBe('1999-09-21')
-    expect(translateDate('21oct1999')).toBe('1999-10-21')
-    expect(translateDate('21nov1999')).toBe('1999-11-21')
-    expect(translateDate('21dec1999')).toBe('1999-12-21')
-
-    expect(translateDate('21xxx1999')).toBe(null)
   })
 })

--- a/test/international-interventions-parser.test.ts
+++ b/test/international-interventions-parser.test.ts
@@ -1,0 +1,142 @@
+import {
+  parseCsv,
+  translateDate
+} from '../lib/international-interventions-parser'
+
+// These are 3 rows taken from real data, but modified to include subthreshold levels and backing off of restrictions
+const data = `,,01jan2020,02jan2020,03jan2020,04jan2020,05jan2020,06jan2020,07jan2020,08jan2020,09jan2020,10jan2020,11jan2020
+Aruba,ABW,0,1,2,3,3,2,1,0,,,,
+Afghanistan,AFG,,0,0,1,2,3,3,,2,1,0`
+
+const invalidCountryData = `,,01jan2020,02jan2020,03jan2020,04jan2020,05jan2020,06jan2020,07jan2020,08jan2020,09jan2020,10jan2020,11jan2020
+Aruba,XXX,0,1,2,3,3,2,1,0,,,,`
+
+const kosovoData = `,,01jan2020,02jan2020,03jan2020,04jan2020,05jan2020,06jan2020,07jan2020,08jan2020,09jan2020,10jan2020,11jan2020
+Aruba,RKS,0,1,2,3,3,2,1,0,,,,`
+
+describe('international-interventions-parser', () => {
+  it('should parse csv for level 1', () => {
+    expect(parseCsv(data, 'SchoolClose', 1)).toEqual([
+      {
+        easeDate: null,
+        endDate: '2020-01-08',
+        expirationDate: null,
+        issueDate: null,
+        notes: null,
+        policy: 'SchoolClose',
+        regionId: 'AW',
+        source: null,
+        startDate: '2020-01-02',
+        subregionId: null
+      },
+      {
+        easeDate: null,
+        endDate: '2020-01-11',
+        expirationDate: null,
+        issueDate: null,
+        notes: null,
+        policy: 'SchoolClose',
+        regionId: 'AF',
+        source: null,
+        startDate: '2020-01-04',
+        subregionId: null
+      }
+    ])
+  })
+
+  it('should parse csv for level 2', () => {
+    expect(parseCsv(data, 'SchoolClose', 2)).toEqual([
+      {
+        easeDate: null,
+        endDate: '2020-01-07',
+        expirationDate: null,
+        issueDate: null,
+        notes: null,
+        policy: 'SchoolClose',
+        regionId: 'AW',
+        source: null,
+        startDate: '2020-01-03',
+        subregionId: null
+      },
+      {
+        easeDate: null,
+        endDate: '2020-01-10',
+        expirationDate: null,
+        issueDate: null,
+        notes: null,
+        policy: 'SchoolClose',
+        regionId: 'AF',
+        source: null,
+        startDate: '2020-01-05',
+        subregionId: null
+      }
+    ])
+  })
+
+  it('should parse csv for level 3', () => {
+    expect(parseCsv(data, 'SchoolClose', 3)).toEqual([
+      {
+        easeDate: null,
+        endDate: '2020-01-06',
+        expirationDate: null,
+        issueDate: null,
+        notes: null,
+        policy: 'SchoolClose',
+        regionId: 'AW',
+        source: null,
+        startDate: '2020-01-04',
+        subregionId: null
+      },
+      {
+        easeDate: null,
+        endDate: '2020-01-09',
+        expirationDate: null,
+        issueDate: null,
+        notes: null,
+        policy: 'SchoolClose',
+        regionId: 'AF',
+        source: null,
+        startDate: '2020-01-06',
+        subregionId: null
+      }
+    ])
+  })
+
+  it('should ignore invalid countries', () => {
+    expect(parseCsv(invalidCountryData, 'hucairz', 3)).toEqual([])
+  })
+
+  it('should handle Kosovo', () => {
+    expect(parseCsv(kosovoData, 'SchoolClose', 3)).toEqual([
+      {
+        easeDate: null,
+        endDate: '2020-01-06',
+        expirationDate: null,
+        issueDate: null,
+        notes: null,
+        policy: 'SchoolClose',
+        regionId: 'XK',
+        source: null,
+        startDate: '2020-01-04',
+        subregionId: null
+      }
+    ])
+  })
+
+  it('should parse translate dates', () => {
+    expect(translateDate('21jan1999')).toBe('1999-01-21')
+    expect(translateDate('21feb1999')).toBe('1999-02-21')
+    expect(translateDate('21mar1999')).toBe('1999-03-21')
+    expect(translateDate('21apr1999')).toBe('1999-04-21')
+    expect(translateDate('21may1999')).toBe('1999-05-21')
+    expect(translateDate('21jun1999')).toBe('1999-06-21')
+    expect(translateDate('21jul1999')).toBe('1999-07-21')
+    expect(translateDate('21aug1999')).toBe('1999-08-21')
+    expect(translateDate('21sep1999')).toBe('1999-09-21')
+    expect(translateDate('21oct1999')).toBe('1999-10-21')
+    expect(translateDate('21nov1999')).toBe('1999-11-21')
+    expect(translateDate('21dec1999')).toBe('1999-12-21')
+
+    expect(translateDate('21xxx1999')).toBe(null)
+  })
+})


### PR DESCRIPTION
This is a little bit of a simplification from what I wrote in #17.
We only look at school closures, gathering restrictions, and stay at
home policies.

This is enough to populate the database with interventions. We can
get more specific later if we choose.

Closes #17 