### PR TITLE
Remove production env for fetch-recorded-data

### DIFF
--- a/.github/workflows/fetch-recorded-data.yml
+++ b/.github/workflows/fetch-recorded-data.yml
@@ -9,8 +9,6 @@ jobs:
   fetch-recorded-data:
     name: Fetch recorded case and intervention data
     runs-on: ubuntu-latest
-    env:
-      NODE_ENV: production
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v1


### PR DESCRIPTION
This was preventing ts-node from being installed in the workflow. I think this is fine because running fetch-recorded-data is not really a production thing.