### PR TITLE
Handle missing intervention data for a region

### DIFF
--- a/lib/new-simulation-state.ts
+++ b/lib/new-simulation-state.ts
@@ -287,7 +287,8 @@ function autoFillParameters(
   subregion: Region | undefined,
   interventions: InterventionMap
 ): InterventionPeriod[] {
-  const regionInterventions = interventions[region.id][subregion?.id || '_self']
+  const regionInterventions =
+    interventions?.[region.id]?.[subregion?.id || '_self']
   if (!regionInterventions) {
     return []
   }

--- a/test/new-simulation-state.test.ts
+++ b/test/new-simulation-state.test.ts
@@ -13,7 +13,40 @@ import {InterventionMap, Interventions} from '../lib/simulation-types'
 
 describe('new-simulation-state', () => {
   describe('initializeSimulationState', () => {
-    it('should initialize state with empty interventions', () => {
+    it('should initialize state when there is no intervention data', () => {
+      const state = initializeSimulationState(createMockRegions(), {})
+      expect(state).toEqual({
+        interventionPeriods: [],
+        label: createMockLabel(),
+        ...createMockRegions()
+      })
+    })
+
+    it('should initialize state when there are no interventions for first region', () => {
+      const state = initializeSimulationState(
+        createMockRegions('different-region', 'US-AL'),
+        createMockInterventions()
+      )
+      expect(state).toEqual({
+        interventionPeriods: [],
+        label: createMockLabel(),
+        ...createMockRegions('different-region', 'US-AL')
+      })
+    })
+
+    it('should initialize state when there are no interventions for first subregion', () => {
+      const state = initializeSimulationState(
+        createMockRegions('US', 'different-subregion'),
+        createMockInterventions()
+      )
+      expect(state).toEqual({
+        interventionPeriods: [],
+        label: createMockLabel(),
+        ...createMockRegions('US', 'different-subregion')
+      })
+    })
+
+    it('should initialize state with empty interventions for region', () => {
       const state = initializeSimulationState(
         createMockRegions(),
         createMockInterventions()


### PR DESCRIPTION
Fixes crash in New Simulation page caused by attempting to look up the subregion when the region has no data.