### PR TITLE
Add aliasing to deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ jobs:
           mkdir .now
           echo '{"projectId":"${{secrets.ZEIT_PROJECT_ID}}","orgId":"${{secrets.ZEIT_ORG_ID}}"}' > .now/project.json
       - run: npx now --token ${{secrets.ZEIT_TOKEN}} -b GITHUB_SHA=${{github.sha}} -A now.prod.json
+      # force production to point to the proper deployment since vercel does not do this automatically.
+      - run: npx now --token ${{secrets.ZEIT_TOKEN}} alias web-jclem.covid-modeling.now.sh covid-modeling.org
       - run: |
           npx sentry-cli \
             --auth-token "${{secrets.SENTRY_AUTH_TOKEN}}" \


### PR DESCRIPTION
By default, vercel deploys to a different target. We want to force this to be production.