### PR TITLE
Models: Bump Basel connector to 1.3.0

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -2,7 +2,7 @@ basel:
   name: Covid19-Scenarios (Neher)
   origin: Neher Lab, Biozentrum Basel
   isProductionReady: true
-  imageURL: docker.pkg.github.com/covid-modeling/model-runner/neherlab-covid-19-scenarios-connector:1.2.0
+  imageURL: docker.pkg.github.com/covid-modeling/model-runner/neherlab-covid-19-scenarios-connector:1.3.0
   metaURLs:
     code: https://github.com/neherlab/covid19_scenarios
     website: https://covid19-scenarios.org/about


### PR DESCRIPTION
Model version 1.6.4, with fixes for intervention date handling.