### PR TITLE
Change deploy workflow to 'workflow_dispatch'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,5 @@
-on:
-  repository_dispatch:
-    types: deploy
+name: Deploy
+on: workflow_dispatch
 
 jobs:
   deploy:


### PR DESCRIPTION
This will allow users to run the deploy job directly from the UI.

Currently, this feature is only staff shipped, so external users will not be able to run this until the feature becomes public. This is not (yet) a problem because we don't have any external contributors (yet).